### PR TITLE
Output xml docs to build directory

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,5 @@
 version: '{build}'
 image: Visual Studio 2019
-configuration: Release
-platform: Any CPU
 build_script:
 - pwsh: dotnet build .\src\ConsoleProgressBar\ConsoleProgressBar.csproj -c Release -p:Version="1.0.$env:APPVEYOR_BUILD_VERSION"
 artifacts:

--- a/src/ConsoleProgressBar/ConsoleProgressBar.csproj
+++ b/src/ConsoleProgressBar/ConsoleProgressBar.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <DocumentationFile>C:\repos\console-progress-bar\src\ConsoleProgressBar\ConsoleProgressBar.xml</DocumentationFile>
+    <DocumentationFile>C:\repos\console-progress-bar\src\ConsoleProgressBar\bin\Release\netstandard2.0\ConsoleProgressBar.xml</DocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
The last deployment did not include the xml documentation. This PR fixes that.