### PR TITLE
Rename 'ConsoleProgressBar' to 'Luna.ConsoleProgressBar'

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ dotnet add package Luna.ConsoleProgressBar
 ![Progress Bar_Ubuntu](https://s3-us-west-1.amazonaws.com/alunapublic/console_progress_bar/ProgressBar_Ubuntu.gif)
 
 ## Usage
-Numbers correspond to the examples shown above, full source code for examples can be found in [the demo project](https://github.com/refactorsaurusrex/console-progress-bar/blob/master/src/ConsoleProgressBar.Demo/Program.cs).
+Numbers correspond to the examples shown above, full source code for examples can be found in [the demo project](https://github.com/refactorsaurusrex/console-progress-bar/blob/master/src/Luna.ConsoleProgressBar.Demo/Program.cs).
 ```csharp
 // 1. Default behavior
 var pb1 = new ConsoleProgressBar();

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,10 +1,10 @@
 version: '{build}'
 image: Visual Studio 2019
 build_script:
-- pwsh: dotnet build .\src\ConsoleProgressBar\ConsoleProgressBar.csproj -c Release -p:Version="1.0.$env:APPVEYOR_BUILD_VERSION"
+- pwsh: dotnet build .\src\Luna.ConsoleProgressBar\Luna.ConsoleProgressBar.csproj -c Release -p:Version="1.0.$env:APPVEYOR_BUILD_VERSION"
 artifacts:
 - path: '**\*.nupkg'
-  name: console-progress-bar
+  name: Luna.ConsoleProgressBar
 deploy:
 - provider: NuGet
   api_key:

--- a/src/ConsoleProgressBar.sln
+++ b/src/ConsoleProgressBar.sln
@@ -2,9 +2,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.29806.167
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConsoleProgressBar.Demo", "ConsoleProgressBar.Demo\ConsoleProgressBar.Demo.csproj", "{E3379E91-0902-41D5-AF32-00005AC857A0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Luna.ConsoleProgressBar.Demo", "Luna.ConsoleProgressBar.Demo\Luna.ConsoleProgressBar.Demo.csproj", "{E3379E91-0902-41D5-AF32-00005AC857A0}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConsoleProgressBar", "ConsoleProgressBar\ConsoleProgressBar.csproj", "{48A974D0-EE4D-4C30-B038-B5B33A27B7CB}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Luna.ConsoleProgressBar", "Luna.ConsoleProgressBar\Luna.ConsoleProgressBar.csproj", "{48A974D0-EE4D-4C30-B038-B5B33A27B7CB}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/ConsoleProgressBar/AssemblyInfo.cs
+++ b/src/ConsoleProgressBar/AssemblyInfo.cs
@@ -1,3 +1,0 @@
-﻿using System.Runtime.CompilerServices;
-
-[assembly: InternalsVisibleTo("ConsoleProgressBar.Demo")]

--- a/src/Luna.ConsoleProgressBar.Demo/Luna.ConsoleProgressBar.Demo.csproj
+++ b/src/Luna.ConsoleProgressBar.Demo/Luna.ConsoleProgressBar.Demo.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <AssemblyName>ConsoleProgressBar.Demo</AssemblyName>
-    <RootNamespace>ConsoleProgressBar.Demo</RootNamespace>
+    <AssemblyName>Luna.ConsoleProgressBar.Demo</AssemblyName>
+    <RootNamespace>Luna.ConsoleProgressBar.Demo</RootNamespace>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -14,6 +14,6 @@
     <LangVersion>Latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="..\ConsoleProgressBar\ConsoleProgressBar.csproj" />
+    <ProjectReference Include="..\Luna.ConsoleProgressBar\Luna.ConsoleProgressBar.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Luna.ConsoleProgressBar.Demo/Program.cs
+++ b/src/Luna.ConsoleProgressBar.Demo/Program.cs
@@ -1,9 +1,8 @@
 ﻿using System;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace ConsoleProgressBar.Demo
+namespace Luna.ConsoleProgressBar.Demo
 {
     internal static class Program
     {

--- a/src/Luna.ConsoleProgressBar.sln.DotSettings
+++ b/src/Luna.ConsoleProgressBar.sln.DotSettings
@@ -1,0 +1,4 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=KB/@EntryIndexedValue">KB</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=MB/@EntryIndexedValue">MB</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=GB/@EntryIndexedValue">GB</s:String></wpf:ResourceDictionary>

--- a/src/Luna.ConsoleProgressBar/AssemblyInfo.cs
+++ b/src/Luna.ConsoleProgressBar/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Luna.ConsoleProgressBar.Demo")]

--- a/src/Luna.ConsoleProgressBar/ConsoleProgressBar.cs
+++ b/src/Luna.ConsoleProgressBar/ConsoleProgressBar.cs
@@ -3,7 +3,7 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 
-namespace ConsoleProgressBar
+namespace Luna.ConsoleProgressBar
 {
     /// <summary>
     /// Represents a text-based progress bar, for display in C# console applications. 

--- a/src/Luna.ConsoleProgressBar/Extensions.cs
+++ b/src/Luna.ConsoleProgressBar/Extensions.cs
@@ -1,6 +1,6 @@
 ﻿using System.Linq;
 
-namespace ConsoleProgressBar
+namespace Luna.ConsoleProgressBar
 {
     internal static class Extensions
     {

--- a/src/Luna.ConsoleProgressBar/FileSize.cs
+++ b/src/Luna.ConsoleProgressBar/FileSize.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.IO;
-using System.Linq;
-using System.Security;
-
-namespace ConsoleProgressBar
+﻿namespace Luna.ConsoleProgressBar
 {
     internal class FileSize
     {

--- a/src/Luna.ConsoleProgressBar/FileTransferProgressBar.cs
+++ b/src/Luna.ConsoleProgressBar/FileTransferProgressBar.cs
@@ -2,7 +2,7 @@
 using System.Linq;
 using System.Threading;
 
-namespace ConsoleProgressBar
+namespace Luna.ConsoleProgressBar
 {
     /// <summary>
     /// Represents a text-based progress bar for tracking file transfers in C# console applications. 

--- a/src/Luna.ConsoleProgressBar/IMarqueeParameters.cs
+++ b/src/Luna.ConsoleProgressBar/IMarqueeParameters.cs
@@ -1,4 +1,4 @@
-﻿namespace ConsoleProgressBar
+﻿namespace Luna.ConsoleProgressBar
 {
     internal interface IMarqueeParameters
     {

--- a/src/Luna.ConsoleProgressBar/Luna.ConsoleProgressBar.csproj
+++ b/src/Luna.ConsoleProgressBar/Luna.ConsoleProgressBar.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <DocumentationFile>C:\repos\console-progress-bar\src\ConsoleProgressBar\bin\Release\netstandard2.0\ConsoleProgressBar.xml</DocumentationFile>
+    <DocumentationFile>C:\repos\console-progress-bar\src\Luna.ConsoleProgressBar\bin\Release\netstandard2.0\Luna.ConsoleProgressBar.xml</DocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/Luna.ConsoleProgressBar/MacOnlyProgressAnimations.cs
+++ b/src/Luna.ConsoleProgressBar/MacOnlyProgressAnimations.cs
@@ -1,7 +1,8 @@
 ﻿using JetBrains.Annotations;
+
 #pragma warning disable 1591
 
-namespace ConsoleProgressBar
+namespace Luna.ConsoleProgressBar
 {
     /// <summary>
     /// A collection of progress bar animations that only work correctly on Macs.

--- a/src/Luna.ConsoleProgressBar/Marquee.cs
+++ b/src/Luna.ConsoleProgressBar/Marquee.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace ConsoleProgressBar
+namespace Luna.ConsoleProgressBar
 {
     internal class Marquee
     {

--- a/src/Luna.ConsoleProgressBar/MarqueeProgressBar.cs
+++ b/src/Luna.ConsoleProgressBar/MarqueeProgressBar.cs
@@ -3,7 +3,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace ConsoleProgressBar
+namespace Luna.ConsoleProgressBar
 {
     /// <summary>
     /// Represents a text-based marquee-style progress bar, for display in C# console applications. 

--- a/src/Luna.ConsoleProgressBar/ProgressEventArgs.cs
+++ b/src/Luna.ConsoleProgressBar/ProgressEventArgs.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using JetBrains.Annotations;
 
-namespace ConsoleProgressBar
+namespace Luna.ConsoleProgressBar
 {
     /// <inheritdoc />
     [PublicAPI]

--- a/src/Luna.ConsoleProgressBar/UniversalProgressAnimations.cs
+++ b/src/Luna.ConsoleProgressBar/UniversalProgressAnimations.cs
@@ -1,7 +1,8 @@
 ﻿using JetBrains.Annotations;
+
 #pragma warning disable 1591
 
-namespace ConsoleProgressBar
+namespace Luna.ConsoleProgressBar
 {
     /// <summary>
     /// A collection of progress bar animations that work correctly on both Mac and Windows machines.


### PR DESCRIPTION
This all started because I couldn't publish a new nuget package named
'ConsoleProgressBar' because - surprise! - a package already exists
with that name. So I decided to name it 'Luna.ConsoleProgressBar' instead
to pay homage to the project's original author. Later, after publishing,
I imported the package into another project I'm working on and noticed that
I had to declare a new ConsoleProgressBar as...

```
var c = new ConsoleProgressBar.ConsoleProgressBar();
```

...in order to disambiguate the class name from the namespace name, which
is just plain stupid. So now I took my earlier rename to its logical
extreme, which will allow new ConsoleProgressBar() to be declared without
fully qualifiying it with the namespace name. Hopefully this ends The
Great Rename Saga of 2020.